### PR TITLE
Clean Architecture: Move @Serializable out of the model classes.

### DIFF
--- a/app/src/main/java/com/handstandsam/shoppingapp/features/category/CategoryActivity.kt
+++ b/app/src/main/java/com/handstandsam/shoppingapp/features/category/CategoryActivity.kt
@@ -24,8 +24,8 @@ class CategoryActivity : LoggedInActivity() {
                 .get(CategoryViewModel::class.java)
 
             val extras = intent.extras
-            val category = extras!!.get(BUNDLE_PARAM_CATEGORY) as Category
-            categoryViewModel.send(CategoryViewModel.Intention.CategoryLabelSet(category.label))
+            val categoryLabel = extras!!.getString(BUNDLE_PARAM_CATEGORY)!!
+            categoryViewModel.send(CategoryViewModel.Intention.CategoryLabelSet(categoryLabel))
 
             setContent {
                 CategoryScreen(
@@ -60,7 +60,7 @@ class CategoryActivity : LoggedInActivity() {
         fun launch(context: Context, category: Category) {
             val intent = Intent(context, CategoryActivity::class.java)
             val extras = Bundle()
-            extras.putSerializable(BUNDLE_PARAM_CATEGORY, category)
+            extras.putString(BUNDLE_PARAM_CATEGORY, category.label)
             intent.putExtras(extras)
             context.startActivity(intent)
         }

--- a/app/src/main/java/com/handstandsam/shoppingapp/features/itemdetail/ItemDetailActivity.kt
+++ b/app/src/main/java/com/handstandsam/shoppingapp/features/itemdetail/ItemDetailActivity.kt
@@ -83,10 +83,10 @@ class ItemDetailActivity : LoggedInActivity() {
     }
 
     companion object {
-        internal fun launch(context: Context, item: Item?) {
+        internal fun launch(context: Context, item: Item) {
             val intent = Intent(context, ItemDetailActivity::class.java)
             val extras = Bundle()
-            extras.putSerializable(ItemDetailPresenter.BUNDLE_PARAM_ITEM, item)
+            extras.putSerializable(ItemDetailPresenter.BUNDLE_PARAM_ITEM, ItemDetailData.fromItem(item))
             intent.putExtras(extras)
             context.startActivity(intent)
         }

--- a/app/src/main/java/com/handstandsam/shoppingapp/features/itemdetail/ItemDetailData.kt
+++ b/app/src/main/java/com/handstandsam/shoppingapp/features/itemdetail/ItemDetailData.kt
@@ -1,0 +1,29 @@
+package com.handstandsam.shoppingapp.features.itemdetail
+
+import com.handstandsam.shoppingapp.models.Item
+import java.io.Serializable
+
+data class ItemDetailData(
+    val label: String,
+    val image: String,
+    val link: String? = null
+) : Serializable {
+
+    fun toItem(): Item {
+        return Item(
+            label = label,
+            image = image,
+            link = link
+        )
+    }
+
+    companion object {
+        fun fromItem(item: Item): ItemDetailData {
+            return ItemDetailData(
+                label = item.label,
+                image = item.image,
+                link = item.link
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/handstandsam/shoppingapp/features/itemdetail/ItemDetailPresenter.kt
+++ b/app/src/main/java/com/handstandsam/shoppingapp/features/itemdetail/ItemDetailPresenter.kt
@@ -1,12 +1,12 @@
 package com.handstandsam.shoppingapp.features.itemdetail
 
 import android.content.Intent
-import androidx.lifecycle.LifecycleCoroutineScope
 import com.handstandsam.shoppingapp.cart.ShoppingCart
 import com.handstandsam.shoppingapp.models.Item
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.Serializable
 
 class ItemDetailPresenter(
     private val view: ItemDetailActivity.ItemDetailView,
@@ -16,8 +16,8 @@ class ItemDetailPresenter(
 
     fun onResume(intent: Intent) {
         val extras = intent.extras
-        val item = extras!!.get(BUNDLE_PARAM_ITEM) as Item
-        this.item = item
+        val item = extras!!.get(BUNDLE_PARAM_ITEM) as ItemDetailData
+        this.item = item.toItem()
 
         view.setLabel(item.label)
         view.setImageUrl(item.image)

--- a/models/src/main/java/com/handstandsam/shoppingapp/models/Category.kt
+++ b/models/src/main/java/com/handstandsam/shoppingapp/models/Category.kt
@@ -1,5 +1,3 @@
 package com.handstandsam.shoppingapp.models
 
-import java.io.Serializable
-
-data class Category(val label: String, val image: String, val link: String? = null) : Serializable
+data class Category(val label: String, val image: String, val link: String? = null)

--- a/models/src/main/java/com/handstandsam/shoppingapp/models/Item.kt
+++ b/models/src/main/java/com/handstandsam/shoppingapp/models/Item.kt
@@ -1,9 +1,7 @@
 package com.handstandsam.shoppingapp.models
 
-import java.io.Serializable
-
 data class Item(
     val label: String,
     val image: String,
     val link: String? = null
-) : Serializable
+)

--- a/models/src/main/java/com/handstandsam/shoppingapp/models/User.kt
+++ b/models/src/main/java/com/handstandsam/shoppingapp/models/User.kt
@@ -1,5 +1,3 @@
 package com.handstandsam.shoppingapp.models
 
-import java.io.Serializable
-
-data class User(val firstname: String, val lastname: String) : Serializable
+data class User(val firstname: String, val lastname: String)


### PR DESCRIPTION
Moving `@Serializable` code to the Android module to remove reliance on the JVM.  This allows us to make the model class multiplatform compatible in a subsequent PR.