### PR TITLE
JVM -> Multiplatform Kotlin Plugin | commonMain, without commonMain

### DIFF
--- a/convention-plugins/src/main/kotlin/com.handstandsam.jvm.lib.gradle.kts
+++ b/convention-plugins/src/main/kotlin/com.handstandsam.jvm.lib.gradle.kts
@@ -1,7 +1,16 @@
 plugins {
-    kotlin("jvm")
+    kotlin("multiplatform")
 }
 
-dependencies {
-    implementation(kotlin("stdlib"))
+kotlin {
+    sourceSets {
+        val main by creating {
+            kotlin.srcDir("src/main/java")
+        }
+        val commonMain by getting {
+            dependsOn(main)
+        }
+    }
+
+    jvm {}
 }

--- a/mock-data/build.gradle.kts
+++ b/mock-data/build.gradle.kts
@@ -3,5 +3,6 @@ plugins {
 }
 
 dependencies {
+    implementation(kotlin("stdlib"))
     implementation(project(":models"))
 }

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("com.handstandsam.jvm.lib")
 }
+
+dependencies {
+   implementation(kotlin("stdlib"))
+}


### PR DESCRIPTION
Uses same project structure, but swaps out the `kotlin("jvm")` plugin for the `kotlin("multiplatform")` plugin so we can build to other targets now as we choose!

NOTE: This assumes that all the kotlin code that you have is compatible with `commonMain`.